### PR TITLE
feat: add clone and install instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This simple Python program downloads all the free PDFs of Raspberry Pi's [MagPi magazine](https://magpi.raspberrypi.com/).
 
 ## Getting started
-To download all the MagPi magazines, make sure you have [Python](https://python.org) installed, then open a terminal window and run the following commands one after the other. The magazine PDFs will be downloaded to a folder called `MagPis` inside the cloned `magpi-download` folder.
+To download all the MagPi magazines, make sure you have [Python](https://python.org) installed, then open a terminal window and run the following commands one after the other. The magazine PDFs will be downloaded to a folder called `MagPi` inside the cloned `magpi-download` folder.
 1. `git clone https://github.com/weasdown/magpi-download.git`
 2. `cd magpi-download`
 3. `python -m venv .venv`

--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ To download all the MagPi magazines, make sure you have [Python](https://python.
 1. `git clone https://github.com/weasdown/magpi-download.git`
 2. `cd magpi-download`
 3. `python -m venv .venv`
-4. `python -m pip install requirements.txt`
-5. `python main.py`
+4. If on Windows: `./.venv/Scripts/activate.bat`, or on Linux/macOS: `source .venv/bin/activate`
+5. `python -m pip install requirements.txt`
+6. `python main.py`

--- a/README.md
+++ b/README.md
@@ -2,11 +2,22 @@
 
 This simple Python program downloads all the free PDFs of Raspberry Pi's [MagPi magazine](https://magpi.raspberrypi.com/).
 
-## Getting started
-To download all the MagPi magazines, make sure you have [Python](https://python.org) installed, then open a terminal window and run the following commands one after the other. The magazine PDFs will be downloaded to a folder called `MagPi` inside the cloned `magpi-download` folder.
+## How to use
+### 
+Firstly, make sure you have [Python](https://python.org) installed, then open a terminal window and run the following commands one after the other.
 1. `git clone https://github.com/weasdown/magpi-download.git`
 2. `cd magpi-download`
 3. `python -m venv .venv`
 4. If on Windows: `./.venv/Scripts/activate.bat`, or on Linux/macOS: `source .venv/bin/activate`
 5. `python -m pip install -U -r requirements.txt`
 6. `python main.py`
+
+To view available commands, run: `python main.py -h` or `python main.py --help`.
+
+### Downloading magazines
+The magazine PDFs will be downloaded to a folder called `MagPis` inside the cloned `magpi-download` folder.
+- To download all the MagPi magazines, run: `python main.py`.
+- To download a single issue, specify its number with the `-i` parameter, run: `python main.py -i 150`.
+- To set the folder that the magazines will download to (`MagPis` by default), use the `-p` parameter, being sure to   wrap the folder name in quotes. For examples, to download to a folder called "issues", run: `python main.py -p "issues"`.
+
+More than one argument can be specified. For example, to download issue 100 to a folder called "magazines", run: `python main.py -i 100 -p "magazines"`.

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ To download all the MagPi magazines, make sure you have [Python](https://python.
 2. `cd magpi-download`
 3. `python -m venv .venv`
 4. If on Windows: `./.venv/Scripts/activate.bat`, or on Linux/macOS: `source .venv/bin/activate`
-5. `pip install -r requirements.txt`
+5. `pip install -U -r requirements.txt`
 6. `python main.py`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # magpi-download
 
 This simple Python program downloads all the free PDFs of Raspberry Pi's [MagPi magazine](https://magpi.raspberrypi.com/).
+
+## Getting started
+To download all the MagPi magazines, make sure you have [Python](https://python.org) installed, then open a terminal window and run the following commands one after the other:
+1. `git clone https://github.com/weasdown/magpi-download.git`
+2. `cd magpi-download`
+3. `python -m venv .venv`
+4. `python -m pip install requirements.txt`
+5. `python main.py`

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ To download all the MagPi magazines, make sure you have [Python](https://python.
 2. `cd magpi-download`
 3. `python -m venv .venv`
 4. If on Windows: `./.venv/Scripts/activate.bat`, or on Linux/macOS: `source .venv/bin/activate`
-5. `python -m pip install -r requirements.txt`
+5. `pip install -r requirements.txt`
 6. `python main.py`

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ To download all the MagPi magazines, make sure you have [Python](https://python.
 2. `cd magpi-download`
 3. `python -m venv .venv`
 4. If on Windows: `./.venv/Scripts/activate.bat`, or on Linux/macOS: `source .venv/bin/activate`
-5. `python -m pip install requirements.txt`
+5. `python -m pip install -r requirements.txt`
 6. `python main.py`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This simple Python program downloads all the free PDFs of Raspberry Pi's [MagPi magazine](https://magpi.raspberrypi.com/).
 
 ## Getting started
-To download all the MagPi magazines, make sure you have [Python](https://python.org) installed, then open a terminal window and run the following commands one after the other:
+To download all the MagPi magazines, make sure you have [Python](https://python.org) installed, then open a terminal window and run the following commands one after the other. The magazine PDFs will be downloaded to a folder called `MagPis` inside the cloned `magpi-download` folder.
 1. `git clone https://github.com/weasdown/magpi-download.git`
 2. `cd magpi-download`
 3. `python -m venv .venv`

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ To download all the MagPi magazines, make sure you have [Python](https://python.
 2. `cd magpi-download`
 3. `python -m venv .venv`
 4. If on Windows: `./.venv/Scripts/activate.bat`, or on Linux/macOS: `source .venv/bin/activate`
-5. `pip install -U -r requirements.txt`
+5. `python -m pip install -U -r requirements.txt`
 6. `python main.py`

--- a/magpi-download.code-workspace
+++ b/magpi-download.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/magpi-download.code-workspace
+++ b/magpi-download.code-workspace
@@ -4,5 +4,27 @@
 			"path": "."
 		}
 	],
-	"settings": {}
+	"settings": {},
+	"launch": {
+		"version": "0.2.0",
+		"configurations": [
+			{
+				"name": "Python Debugger: Current File",
+				"type": "debugpy",
+				"request": "launch",
+				"program": "${file}",
+				"console": "integratedTerminal"
+			},
+			{
+				"name": "Python Debugger: Current File with Arguments",
+				"type": "debugpy",
+				"request": "launch",
+				"program": "${file}",
+				"console": "integratedTerminal",
+				"args": [
+					"${command:pickArgs}"
+				]
+			},
+		]
+	}
 }

--- a/main.py
+++ b/main.py
@@ -73,8 +73,7 @@ latest_issue: int = 149  # as of 29/1/25
 def download_all(save_path: Path) -> None:
     """Download all MagPi PDFs."""
     for issue in range(1, latest_issue+1):
-        issue_object: Issue = Issue(issue)
-        issue_object.download(save_path)
+        Issue(issue).download(save_path)        
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import argparse
 from argparse import ArgumentError
 
 from bs4 import BeautifulSoup
+import json  # TODO remove import if not required
 import os
 from pathlib import Path
 import requests

--- a/main.py
+++ b/main.py
@@ -97,7 +97,7 @@ if __name__ == '__main__':
     # Read arguments from command line
     args = parser.parse_args()
 
-    default_download_folder: Path =Path('D:/Resources/Raspberry Pi magazines/MagPi')
+    default_download_folder: Path =Path('MagPi')
     download_folder: Path = Path(args.path) if args.path is not None else default_download_folder
     if not os.path.exists(download_folder):
         print(f'\t- Directory {download_folder} does not exist - making it...')

--- a/main.py
+++ b/main.py
@@ -1,14 +1,15 @@
 # Program to automatically download every issue of Raspberry Pi's MagPi magazine.
 
+import argparse
+from argparse import ArgumentError
+
 from bs4 import BeautifulSoup
-import json  # TODO remove import if not required
 import os
 from pathlib import Path
 import requests
 import sys
 
-# download_folder: Path = Path(r'')
-download_folder: Path = Path(r'D:\Resources\Raspberry Pi magazines\MagPi') if sys.platform == 'win32' else Path('MagPis')
+help_description = "A Python program to download free PDFs of Raspberry Pi's MagPi magazine."
 
 class Issue:
     def __init__(self, issue_number: int):
@@ -69,18 +70,47 @@ class Issue:
 latest_issue: int = 149  # as of 29/1/25
 
 
-def download_all() -> None:
+def download_all(save_path: Path) -> None:
     """Download all MagPi PDFs."""
     for issue in range(1, latest_issue+1):
         issue_object: Issue = Issue(issue)
-        issue_object.download(download_folder)
+        issue_object.download(save_path)
 
 
 if __name__ == '__main__':
+    download_folder: Path = Path('D:/Resources/Raspberry Pi magazines/MagPi') if sys.platform == 'win32' else Path('MagPis')
     if not os.path.exists(download_folder):
         os.mkdir(download_folder)
 
-    download_all()
+    # Initialize parser
+    parser = argparse.ArgumentParser(description=help_description)
 
-    # To download a single issue:
-    # Issue(149).download(download_folder)
+    # Adding optional argument
+    parser.add_argument('-a', '--all', help='Download all available issues', required=False)
+
+    # Add optional argument for download path
+    parser.add_argument('-p','--path', help='The path that the PDFs will be stored in once downloaded', required=False)
+
+    # Add optional argument for issue number
+    parser.add_argument('-i', '--issue', help='A single issue number to download', required=False, type=int)
+
+    # Read arguments from command line
+    args = parser.parse_args()
+
+    default_download_folder: Path =Path(r'D:\Resources\Raspberry Pi magazines\MagPi')
+    download_folder: Path = Path(args.path) if args.path is not None else default_download_folder
+
+    issue_num: int | None = args.issue
+
+    print(f'Issue(s) to download: {issue_num if issue_num is not None else 'All'}')
+    if issue_num is None:
+        print('No issue argument was given, so downloading all issues.\n')
+        download_all(download_folder)
+    else:
+        if args.all is not None:
+            raise ArgumentError(args.all, 'Cannot determine which issues to download when -i/--issue and -a/--all are both set. Please use one or the other.')
+        else:
+            print(f'\nDownloading issue {issue_num} to path "{download_folder}"')
+            Issue(issue_num).download(download_folder)
+
+    print('\nDone!')

--- a/main.py
+++ b/main.py
@@ -78,10 +78,6 @@ def download_all(save_path: Path) -> None:
 
 
 if __name__ == '__main__':
-    download_folder: Path = Path('D:/Resources/Raspberry Pi magazines/MagPi') if sys.platform == 'win32' else Path('MagPis')
-    if not os.path.exists(download_folder):
-        os.mkdir(download_folder)
-
     # Initialize parser
     parser = argparse.ArgumentParser(description=help_description)
 
@@ -97,7 +93,7 @@ if __name__ == '__main__':
     # Read arguments from command line
     args = parser.parse_args()
 
-    default_download_folder: Path =Path('MagPi')
+    default_download_folder: Path = Path('MagPi')
     download_folder: Path = Path(args.path) if args.path is not None else default_download_folder
     if not os.path.exists(download_folder):
         print(f'\t- Directory {download_folder} does not exist - making it...')

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 # Program to automatically download every issue of Raspberry Pi's MagPi magazine.
 
 from bs4 import BeautifulSoup
-import json
+import json  # TODO remove import if not required
 import os
 from pathlib import Path
 import requests

--- a/main.py
+++ b/main.py
@@ -96,8 +96,12 @@ if __name__ == '__main__':
     # Read arguments from command line
     args = parser.parse_args()
 
-    default_download_folder: Path =Path(r'D:\Resources\Raspberry Pi magazines\MagPi')
+    default_download_folder: Path =Path('D:/Resources/Raspberry Pi magazines/MagPi')
     download_folder: Path = Path(args.path) if args.path is not None else default_download_folder
+    if not os.path.exists(download_folder):
+        print(f'\t- Directory {download_folder} does not exist - making it...')
+        os.mkdir(download_folder)
+        print(f'\t- Created directory {download_folder}')
 
     issue_num: int | None = args.issue
 

--- a/main.py
+++ b/main.py
@@ -74,7 +74,7 @@ latest_issue: int = 149  # as of 29/1/25
 def download_all(save_path: Path) -> None:
     """Download all MagPi PDFs."""
     for issue in range(1, latest_issue+1):
-        Issue(issue).download(save_path)        
+        Issue(issue).download(save_path)
 
 
 if __name__ == '__main__':
@@ -93,7 +93,7 @@ if __name__ == '__main__':
     # Read arguments from command line
     args = parser.parse_args()
 
-    default_download_folder: Path = Path('MagPi')
+    default_download_folder: Path = Path('MagPis')
     download_folder: Path = Path(args.path) if args.path is not None else default_download_folder
     if not os.path.exists(download_folder):
         print(f'\t- Directory {download_folder} does not exist - making it...')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+beautifulsoup4==4.13.3
+certifi==2025.1.31
+charset-normalizer==3.4.1
+idna==3.10
+requests==2.32.3
+soupsieve==2.6
+typing_extensions==4.12.2
+urllib3==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pip
 beautifulsoup4==4.13.3
 certifi==2025.1.31
 charset-normalizer==3.4.1


### PR DESCRIPTION
Adds instructions to [README.md](https://github.com/weasdown/magpi-download/blob/README-instructions/README.md) about how to setup and use this package.